### PR TITLE
Removed trailing comma in skill.json

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -11,7 +11,7 @@
             ],
             "keywords": [],
             "name": "Facts Sample w/In Skill Purchasing",
-            "description": "Sample Full Description",
+            "description": "Sample Full Description"
           }
         },
         "isAvailableWorldwide": true,


### PR DESCRIPTION
When using ask cli in Python 3.6 to deploy this code to the Developer Console, the trailing comma on line 14 causes an "invalid json" error. I've just removed that trailing comma to produce valid json.

*Issue #, if available:* None

*Description of changes:* Removed trailing comma that was creating invalid json.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
